### PR TITLE
Allow Opentracing 2.0 as dependency, make tests run in Python 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     platforms='any',
     install_requires=[
         'sqlalchemy',
-        'opentracing>=1.1,<=1.3'
+        'opentracing>=1.1,<2.1'
     ],
     classifiers=[
         'Intended Audience :: Developers',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -163,7 +163,7 @@ class TestSQLAlchemyCore(unittest.TestCase):
         self.assertEqual(True, all(map(lambda x: x.is_finished, tracer.spans)))
         self.assertEqual(True, all(map(lambda x: x.child_of == parent_span, tracer.spans)))
         self.assertEqual(['create_table', 'insert', 'select'],
-                         map(lambda x: x.operation_name, tracer.spans))
+                         list(map(lambda x: x.operation_name, tracer.spans)))
 
     def test_traced_transaction_nested(self):
         tracer = DummyTracer()
@@ -189,7 +189,7 @@ class TestSQLAlchemyCore(unittest.TestCase):
         self.assertEqual(True, all(map(lambda x: x.is_finished, tracer.spans)))
         self.assertEqual(True, all(map(lambda x: x.child_of == parent_span, tracer.spans)))
         self.assertEqual(['create_table', 'insert', 'select'],
-                         map(lambda x: x.operation_name, tracer.spans))
+                         list(map(lambda x: x.operation_name, tracer.spans)))
 
     def test_traced_rollback(self):
         tracer = DummyTracer()
@@ -216,9 +216,9 @@ class TestSQLAlchemyCore(unittest.TestCase):
         self.assertEqual(True, all(map(lambda x: x.is_finished, tracer.spans)))
         self.assertEqual(True, all(map(lambda x: x.child_of == parent_span, tracer.spans)))
         self.assertEqual(['insert', 'create_table'],
-                         map(lambda x: x.operation_name, tracer.spans))
+                         list(map(lambda x: x.operation_name, tracer.spans)))
         self.assertEqual(['false', 'true'],
-                         map(lambda x: x.tags.get('error', 'false'), tracer.spans))
+                         list(map(lambda x: x.tags.get('error', 'false'), tracer.spans)))
 
     def test_traced_after_transaction(self):
         tracer = DummyTracer()

--- a/tests/test_orm.py
+++ b/tests/test_orm.py
@@ -1,4 +1,5 @@
 import unittest
+from builtins import range
 from sqlalchemy import create_engine, MetaData, Table, Column, Integer, String
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.exc import IntegrityError, OperationalError
@@ -262,7 +263,7 @@ class TestSQLAlchemyORM(unittest.TestCase):
         parent_span = DummySpan('parent')
         session = self.session
         sqlalchemy_opentracing.set_parent_span(session, parent_span)
-        users = [User(name = 'User-%s' % i) for i in xrange(10)]
+        users = [User(name = 'User-%s' % i) for i in range(10)]
         session.bulk_save_objects(users)
 
         self.assertEqual(1, len(tracer.spans))


### PR DESCRIPTION
From some initial testing this seems to work fine with Python OT 2.0, and tests pass for me after making them forwards compatible with Python 3.

Would be nice to get a new release with this, especially since https://github.com/opentracing-contrib/python-flask is now using `opentracing>=2.0,<2.1`